### PR TITLE
Fix nil responses

### DIFF
--- a/src/redo_redis_proto.erl
+++ b/src/redo_redis_proto.erl
@@ -146,6 +146,9 @@ read_line(<<>>, _Acc) ->
 read_line(<<C, Rest/binary>>, Acc) ->
     read_line(Rest, <<Acc/binary, C>>).
 
+multi_bulk(_, Num, Rest) when Num < 0 ->
+     {ok, nil, {raw, Rest}};
+
 multi_bulk(Acc, 0, Rest) ->
     {ok, lists:reverse(Acc), {raw, Rest}};
 

--- a/src/redo_redis_proto.erl
+++ b/src/redo_redis_proto.erl
@@ -146,11 +146,11 @@ read_line(<<>>, _Acc) ->
 read_line(<<C, Rest/binary>>, Acc) ->
     read_line(Rest, <<Acc/binary, C>>).
 
-multi_bulk(_, Num, Rest) when Num < 0 ->
-     {ok, nil, {raw, Rest}};
-
 multi_bulk(Acc, 0, Rest) ->
     {ok, lists:reverse(Acc), {raw, Rest}};
+
+multi_bulk(_, Num, Rest) when Num < 0 ->
+     {ok, undefined, {raw, Rest}};
 
 multi_bulk(Acc, Num, <<>>) ->
     {eof, Acc, {multi_bulk, Num, <<>>}};

--- a/test/redo_tests.erl
+++ b/test/redo_tests.erl
@@ -23,7 +23,6 @@
 -module(redo_tests).
 -include_lib("eunit/include/eunit.hrl").
 
-
 redis_uri_test() ->
     ?assertEqual([{host, "127.0.0.1"},
                   {port, 666},
@@ -74,6 +73,6 @@ redis_proto_test() ->
                  redo_redis_proto:parse([], {raw, <<"$3\r\nFOO\r\n">>})),
     ?assertEqual({ok, 1234, {raw, <<>>}},
                  redo_redis_proto:parse([], {raw, <<":1234\r\n">>})),
-    ?assertEqual({ok,nil,{raw,<<>>}},
+    ?assertEqual({ok, undefined, {raw,<<>>}},
                  redo_redis_proto:parse([], {raw, <<"*-1\r\n">>})),
     ok.

--- a/test/redo_tests.erl
+++ b/test/redo_tests.erl
@@ -23,6 +23,7 @@
 -module(redo_tests).
 -include_lib("eunit/include/eunit.hrl").
 
+
 redis_uri_test() ->
     ?assertEqual([{host, "127.0.0.1"},
                   {port, 666},
@@ -58,32 +59,21 @@ redis_uri_test() ->
     ?assertEqual([], redo_uri:parse("redis://")),
 
     ?assertEqual([], redo_uri:parse("")),
-
     ok.
 
 redis_proto_test() ->
-    redo_redis_proto:parse(
-        fun(Val) -> ?assertEqual(undefined, Val) end,
-        {raw, <<"$-1\r\n">>}),
-
-    redo_redis_proto:parse(
-        fun(Val) -> ?assertEqual(<<>>, Val) end,
-        {raw, <<"$0\r\n\r\n">>}),
-
-    redo_redis_proto:parse(
-        fun(Val) -> ?assertEqual(<<"OK">>, Val) end,
-        {raw, <<"+OK\r\n">>}),
-
-    redo_redis_proto:parse(
-        fun(Val) -> ?assertEqual({error, <<"Error">>}, Val) end,
-        {raw, <<"-Error\r\n">>}),
- 
-    redo_redis_proto:parse(
-        fun(Val) -> ?assertEqual(<<"FOO">>, Val) end,
-        {raw, <<"$3\r\nFOO\r\n">>}),
-
-    redo_redis_proto:parse(
-        fun(Val) -> ?assertEqual(1234, Val) end,
-        {raw, <<":1234\r\n">>}),
-
+    ?assertEqual({ok, undefined, {raw,<<>>}},
+                 redo_redis_proto:parse([], {raw, <<"$-1\r\n">>})),
+    ?assertEqual({ok, <<>>, {raw, <<>>}},
+                 redo_redis_proto:parse([], {raw, <<"$0\r\n\r\n">>})),
+    ?assertEqual({ok, <<"OK">>,{raw, <<>>}},
+                 redo_redis_proto:parse([], {raw, <<"+OK\r\n">>})),
+    ?assertEqual({ok, {error, <<"Error">>}, {raw, <<>>}},
+                 redo_redis_proto:parse([], {raw, <<"-Error\r\n">>})),
+    ?assertEqual({ok, <<"FOO">>, {raw, <<>>}},
+                 redo_redis_proto:parse([], {raw, <<"$3\r\nFOO\r\n">>})),
+    ?assertEqual({ok, 1234, {raw, <<>>}},
+                 redo_redis_proto:parse([], {raw, <<":1234\r\n">>})),
+    ?assertEqual({ok,nil,{raw,<<>>}},
+                 redo_redis_proto:parse([], {raw, <<"*-1\r\n">>})),
     ok.


### PR DESCRIPTION
The following fails

``` Erlang
redo:start_link().
redo:cmd([<<"BLPOP">>, <<"testing">>, 2]).
```

It should timeout and return nil

> When BLPOP causes a client to block and a non-zero timeout is specified, the client will unblock 
> returning a nil multi-bulk value when the specified timeout has expired without a push operation
> against at least one of the specified keys.

The bug is that it returns a multi-bulk with -1 remaining blocks, which means that currently, the code waits for those -1 further blocks, which will never come (it handles 0 further blocks fine).

I'm not sure if this should return nil, or the value of Acc (which is an empty list), so I'm open to improvements there...

Also, the tests for this logic were not actually doing anything, I fixed them up to work, but there might be shorter/better ways of doing this.
