### PR TITLE
Add mechanism for extracting stats from Redis.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 src/*.swp
 ebin
 .eunit
+.rebar

--- a/src/redo_stats.erl
+++ b/src/redo_stats.erl
@@ -45,15 +45,15 @@ get_stats_cmd(Section) ->
 
 parse_response(Response) ->
     Lines = binary:split(Response, <<"\r\n">>, [global]),
-    {undefined, Sections, []} = lists:foldl(fun parse_line/2, {undefined, [], []}, Lines),
+    {undefined, [], Sections} = lists:foldl(fun parse_line/2, {undefined, [], []}, Lines),
     Sections.
 
-parse_line(<<>>, {Section, AllSections, CurrentSection}) ->
-    {undefined, [{Section, lists:reverse(CurrentSection)} | AllSections], []};
+parse_line(<<>>, {Section, CurrentSection, AllSections}) ->
+    {undefined, [], [{Section, lists:reverse(CurrentSection)} | AllSections]};
 
-parse_line(<<"# ", Section/binary>>, {undefined, AllSections, CurrentSection}) ->
-    {Section, AllSections, CurrentSection};
+parse_line(<<"# ", Section/binary>>, {undefined, CurrentSection, AllSections}) ->
+    {Section, CurrentSection, AllSections} ;
 
-parse_line(Line, {Section, AllSections, CurrentSection}) ->
+parse_line(Line, {Section, CurrentSection, AllSections}) ->
     [Key, Value] = binary:split(Line, <<":">>),
-    {Section, AllSections, [{Key, Value} | CurrentSection]}.
+    {Section, [{Key, Value} | CurrentSection], AllSections}.

--- a/src/redo_stats.erl
+++ b/src/redo_stats.erl
@@ -46,7 +46,7 @@ get_stats_cmd(Section) ->
 parse_response(Response) ->
     Lines = binary:split(Response, <<"\r\n">>, [global]),
     {undefined, [], Sections} = lists:foldl(fun parse_line/2, {undefined, [], []}, Lines),
-    Sections.
+    lists:reverse(Sections).
 
 parse_line(<<>>, {Section, CurrentSection, AllSections}) ->
     {undefined, [], [{Section, lists:reverse(CurrentSection)} | AllSections]};

--- a/src/redo_stats.erl
+++ b/src/redo_stats.erl
@@ -1,0 +1,56 @@
+%% Copyright (C) 2015 Heroku, Inc.
+%%
+%% Permission is hereby granted, free of charge, to any person
+%% obtaining a copy of this software and associated documentation
+%% files (the "Software"), to deal in the Software without
+%% restriction, including without limitation the rights to use,
+%% copy, modify, merge, publish, distribute, sublicense, and/or sell
+%% copies of the Software, and to permit persons to whom the
+%% Software is furnished to do so, subject to the following
+%% conditions:
+%%
+%% The above copyright notice and this permission notice shall be
+%% included in all copies or substantial portions of the Software.
+%%
+%% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+%% EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+%% OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+%% NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+%% HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+%% WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+%% FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+%% OTHER DEALINGS IN THE SOFTWARE.
+-module(redo_stats).
+
+-export([get_stats/1]).
+
+-ifdef(TEST).
+-compile(export_all).
+-endif.
+
+%% Fetch the stats from Redis and return a proplist of values.
+-spec get_stats(atom() | pid()) -> [{term(), binary()}] | {'error', Reason::term()}.
+get_stats(Conn) ->
+    parse_response(redo:cmd(Conn, get_stats_cmd())).
+
+%%--------------------------------------------------------------------
+%% Internal functions
+%%--------------------------------------------------------------------
+
+get_stats_cmd() ->
+    [<<"INFO">>, <<"default">>].
+
+parse_response(Response) ->
+    Lines = re:split(Response, <<"\r\n">>),
+    {undefined, Sections, []} = lists:foldl(fun parse_line/2, {undefined, [], []}, Lines),
+    Sections.
+
+parse_line(<<>>, {Section, AllSections, CurrentSection}) ->
+    {undefined, [{Section, CurrentSection}] ++ AllSections, []};
+
+parse_line(<<"# ", Section/binary>>, {undefined, AllSections, CurrentSection}) ->
+    {Section, AllSections, CurrentSection};
+
+parse_line(Line, {Section, AllSections, CurrentSection}) ->
+    [Key, Value] = binary:split(Line, <<":">>),
+    {Section, AllSections, [{Key, Value}] ++ CurrentSection}.

--- a/test/redo_stats_tests.erl
+++ b/test/redo_stats_tests.erl
@@ -36,13 +36,15 @@ parse_line_test() ->
     ?assertEqual({<<"Server">>, [], []},
                  redo_stats:parse_line(<<"# Server">>, {undefined, [], []})),
 
-    ?assertEqual({undefined, [], [{<<"version">>, <<"2.8.19">>}]},
+    %% When we find a new key, it should be added to the current section.
+    ?assertEqual({undefined, [{<<"version">>, <<"2.8.19">>}], []},
                  redo_stats:parse_line(<<"version:2.8.19">>, {undefined, [], []})),
 
-    ?assertEqual({undefined, [], [{<<"sha1">>, <<"abcdef">>}, {<<"version">>, <<"2.8.19">>}]},
-                 redo_stats:parse_line(<<"sha1:abcdef">>, {undefined, [], [{<<"version">>, <<"2.8.19">>}]})),
+    %% When we find another key, it should be prepended to the current section.
+    ?assertEqual({undefined, [{<<"sha1">>, <<"abcdef">>}, {<<"version">>, <<"2.8.19">>}], []},
+                 redo_stats:parse_line(<<"sha1:abcdef">>, {undefined, [{<<"version">>, <<"2.8.19">>}], []})),
 
-    %% When we add a section to the previous sections, they should be in the
-    %% same order as we found them.
-    ?assertEqual({undefined, [{<<"Server">>, [{<<"sha1">>, <<"abcdef">>}, {<<"version">>, <<"1.0">>}]}], []},
-                 redo_stats:parse_line(<<>>, {<<"Server">>, [], [{<<"version">>, <<"1.0">>},{<<"sha1">>, <<"abcdef">>}]})).
+    %% When we add a new section to the previous sections, the keys should be
+    %% added in the order we identified them.
+    ?assertEqual({undefined, [], [{<<"Server">>, [{<<"sha1">>, <<"abcdef">>}, {<<"version">>, <<"1.0">>}]}]},
+                 redo_stats:parse_line(<<>>, {<<"Server">>, [{<<"version">>, <<"1.0">>},{<<"sha1">>, <<"abcdef">>}], []})).

--- a/test/redo_stats_tests.erl
+++ b/test/redo_stats_tests.erl
@@ -25,15 +25,24 @@
 
 parse_response_test() ->
     Response = <<"# Server\r\nversion:2.8.19\r\nsha1:00000000\r\n">>,
-    ?assertEqual([{<<"Server">>, [{<<"sha1">>, <<"00000000">>}, {<<"version">>, <<"2.8.19">>}]}],
+    ?assertEqual([{<<"Server">>, [{<<"version">>, <<"2.8.19">>}, {<<"sha1">>, <<"00000000">>}]}],
                  redo_stats:parse_response(Response)).
+
+get_stats_cmd_test() ->
+    ?assertEqual([<<"INFO">>, <<"default">>],
+                 redo_stats:get_stats_cmd(<<"default">>)).
 
 parse_line_test() ->
     ?assertEqual({<<"Server">>, [], []},
                  redo_stats:parse_line(<<"# Server">>, {undefined, [], []})),
+
     ?assertEqual({undefined, [], [{<<"version">>, <<"2.8.19">>}]},
                  redo_stats:parse_line(<<"version:2.8.19">>, {undefined, [], []})),
+
     ?assertEqual({undefined, [], [{<<"sha1">>, <<"abcdef">>}, {<<"version">>, <<"2.8.19">>}]},
                  redo_stats:parse_line(<<"sha1:abcdef">>, {undefined, [], [{<<"version">>, <<"2.8.19">>}]})),
-    ?assertEqual({undefined, [{<<"Server">>, [{<<"sha1">>, <<"abcdef">>}]}], []},
-                 redo_stats:parse_line(<<>>, {<<"Server">>, [], [{<<"sha1">>, <<"abcdef">>}]})).
+
+    %% When we add a section to the previous sections, they should be in the
+    %% same order as we found them.
+    ?assertEqual({undefined, [{<<"Server">>, [{<<"sha1">>, <<"abcdef">>}, {<<"version">>, <<"1.0">>}]}], []},
+                 redo_stats:parse_line(<<>>, {<<"Server">>, [], [{<<"version">>, <<"1.0">>},{<<"sha1">>, <<"abcdef">>}]})).

--- a/test/redo_stats_tests.erl
+++ b/test/redo_stats_tests.erl
@@ -24,9 +24,14 @@
 -include_lib("eunit/include/eunit.hrl").
 
 parse_response_test() ->
-    Response = <<"# Server\r\nversion:2.8.19\r\nsha1:00000000\r\n">>,
+    Response1 = <<"# Server\r\nversion:2.8.19\r\nsha1:00000000\r\n">>,
     ?assertEqual([{<<"Server">>, [{<<"version">>, <<"2.8.19">>}, {<<"sha1">>, <<"00000000">>}]}],
-                 redo_stats:parse_response(Response)).
+                 redo_stats:parse_response(Response1)),
+
+    Response2 = <<"# Server\r\nversion:2.8.19\r\n\r\n# Client\r\nvalue:2000\r\n">>,
+    ?assertEqual([{<<"Server">>, [{<<"version">>, <<"2.8.19">>}]},
+                  {<<"Client">>, [{<<"value">>, <<"2000">>}]}],
+                 redo_stats:parse_response(Response2)).
 
 get_stats_cmd_test() ->
     ?assertEqual([<<"INFO">>, <<"default">>],

--- a/test/redo_stats_tests.erl
+++ b/test/redo_stats_tests.erl
@@ -1,0 +1,39 @@
+%% Copyright (C) 2015 Heroku, Inc.
+%%
+%% Permission is hereby granted, free of charge, to any person
+%% obtaining a copy of this software and associated documentation
+%% files (the "Software"), to deal in the Software without
+%% restriction, including without limitation the rights to use,
+%% copy, modify, merge, publish, distribute, sublicense, and/or sell
+%% copies of the Software, and to permit persons to whom the
+%% Software is furnished to do so, subject to the following
+%% conditions:
+%%
+%% The above copyright notice and this permission notice shall be
+%% included in all copies or substantial portions of the Software.
+%%
+%% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+%% EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+%% OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+%% NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+%% HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+%% WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+%% FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+%% OTHER DEALINGS IN THE SOFTWARE.
+-module(redo_stats_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+parse_response_test() ->
+    Response = <<"# Server\r\nversion:2.8.19\r\nsha1:00000000\r\n">>,
+    ?assertEqual([{<<"Server">>, [{<<"sha1">>, <<"00000000">>}, {<<"version">>, <<"2.8.19">>}]}],
+                 redo_stats:parse_response(Response)).
+
+parse_line_test() ->
+    ?assertEqual({<<"Server">>, [], []},
+                 redo_stats:parse_line(<<"# Server">>, {undefined, [], []})),
+    ?assertEqual({undefined, [], [{<<"version">>, <<"2.8.19">>}]},
+                 redo_stats:parse_line(<<"version:2.8.19">>, {undefined, [], []})),
+    ?assertEqual({undefined, [], [{<<"sha1">>, <<"abcdef">>}, {<<"version">>, <<"2.8.19">>}]},
+                 redo_stats:parse_line(<<"sha1:abcdef">>, {undefined, [], [{<<"version">>, <<"2.8.19">>}]})),
+    ?assertEqual({undefined, [{<<"Server">>, [{<<"sha1">>, <<"abcdef">>}]}], []},
+                 redo_stats:parse_line(<<>>, {<<"Server">>, [], [{<<"sha1">>, <<"abcdef">>}]})).


### PR DESCRIPTION
This is an RFC version, it extracts and parses the metrics from Redis.

something like this works...

``` Erlang
1> {ok, Conn} = redo:start_link().
2> Result = redo_stats:get_stats(Conn).
3> proplists:get_value(<<"Memory">>, Result).
[{<<"mem_allocator">>,<<"libc">>},
 {<<"mem_fragmentation_ratio">>,<<"1.40">>},
 {<<"used_memory_lua">>,<<"35840">>},
 {<<"used_memory_peak_human">>,<<"2.46M">>},
 {<<"used_memory_peak">>,<<"2574336">>},
 {<<"used_memory_rss">>,<<"3600384">>},
 {<<"used_memory_human">>,<<"2.46M">>},
 {<<"used_memory">>,<<"2574336">>}]
```
