### PR TITLE
Fix warnings on Erlang 18.1

### DIFF
--- a/src/bench.erl
+++ b/src/bench.erl
@@ -3,19 +3,19 @@
 
 sync(Num) ->
     Redo = setup(),
-    A = now(),
+    A = os:timestamp(),
     ok = loop(Redo, Num),
-    B = now(),
+    B = os:timestamp(),
     print(Num,A,B),
     ok.
 
 async(Num, Concurrency) ->
     Redo = setup(),
     Self = self(),
-    A = now(),
+    A = os:timestamp(),
     Pids = [spawn_link(fun() -> loop(Redo, Num div Concurrency), Self ! {self(), done} end) || _ <- lists:seq(1, Concurrency)],
     [receive {Pid, done} -> ok end || Pid <- Pids],
-    B = now(),
+    B = os:timestamp(),
     print(Num,A,B), 
     ok.
 

--- a/src/redo_concurrency_test.erl
+++ b/src/redo_concurrency_test.erl
@@ -49,7 +49,7 @@ worker(Parent, N, 0) ->
     Parent ! {self(), N, done};
 
 worker(Parent, N, NumOps) ->
-    random:seed(now()),
+    random:seed(os:timestamp()),
     StrN = integer_to_list(N),
     StrOp = integer_to_list(NumOps),
     case random:uniform(100) of

--- a/test/redo_block_tests.erl
+++ b/test/redo_block_tests.erl
@@ -50,7 +50,7 @@ seq_test_() ->
       fun start/0,
       fun stop/1,
       fun(Pid) ->
-        Key = lists:flatten(io_lib:format("~p-~p", [make_ref(),now()])),
+        Key = lists:flatten(io_lib:format("~p-~p", [make_ref(),os:timestamp()])),
         Cmds = [redo_block:cmd(Pid, ["EXISTS", Key]),
                 redo_block:cmd(Pid, ["SET", Key, "1"]),
                 redo_block:cmd(Pid, ["GET", Key]),
@@ -71,7 +71,7 @@ parallel_test_() ->
       fun(Pid) ->
         Parent = self(),
         Keygen = fun() ->
-            iolist_to_binary(io_lib:format("~p-~p", [make_ref(),now()]))
+            iolist_to_binary(io_lib:format("~p-~p", [make_ref(),os:timestamp()]))
         end,
         %% Takes a unique key, inserts it, then reads it. With hundreds of concurrent
         %% processes, if redo_block doesn't behave well, the val read might be different
@@ -97,7 +97,7 @@ timeout_test_() ->
       fun start/0,
       fun stop/1,
       fun(Pid) ->
-        Key = lists:flatten(io_lib:format("~p-~p", [make_ref(),now()])),
+        Key = lists:flatten(io_lib:format("~p-~p", [make_ref(),os:timestamp()])),
         Cmds = [redo_block:cmd(Pid, ["EXISTS", Key]),
                 redo_block:cmd(Pid, ["SET", Key, "1"]),
                 redo_block:cmd(Pid, ["GET", Key], 0),
@@ -119,7 +119,7 @@ parallel_timeout_test_() ->
       fun(Pid) ->
         Parent = self(),
         Keygen = fun() ->
-            iolist_to_binary(io_lib:format("~p-~p", [make_ref(),now()]))
+            iolist_to_binary(io_lib:format("~p-~p", [make_ref(),os:timestamp()]))
         end,
         %% Takes a unique key, inserts it, then reads it. With hundreds of concurrent
         %% processes, if redo_block doesn't behave well, the val read might be different


### PR DESCRIPTION
now() is deprecated in Erlang 18. timestamp() behaves the same on both versions
of Erlang.
