### PR TITLE
Random module is now deprecated

### DIFF
--- a/src/redo_concurrency_test.erl
+++ b/src/redo_concurrency_test.erl
@@ -49,10 +49,10 @@ worker(Parent, N, 0) ->
     Parent ! {self(), N, done};
 
 worker(Parent, N, NumOps) ->
-    random:seed(os:timestamp()),
+    rand:seed(os:timestamp()),
     StrN = integer_to_list(N),
     StrOp = integer_to_list(NumOps),
-    case random:uniform(100) of
+    case rand:uniform(100) of
         R when R > 0, R =< 24 ->
             Key = iolist_to_binary([StrN, ":", StrOp, ":STRING"]),
             Val = iolist_to_binary(["STRING:", StrN, ":", StrOp]),


### PR DESCRIPTION
Fixes the following compilation warnings:

src/redo_concurrency_test.erl:52: Warning: random:seed/1: the 'random' module is deprecated; use the 'rand' module instead
src/redo_concurrency_test.erl:55: Warning: random:uniform/1: the 'random' module is deprecated; use the 'rand' module instead